### PR TITLE
Fix / Minor fixes create campaign

### DIFF
--- a/src/components/JumbotronContentCampaign/__snapshots__/JumbotronContentCampaign.test.jsx.snap
+++ b/src/components/JumbotronContentCampaign/__snapshots__/JumbotronContentCampaign.test.jsx.snap
@@ -18,7 +18,7 @@ exports[`<JumbotronContentCampaign /> renders and matches snapshot 1`] = `
       <span
         class="MuiButton-label"
       >
-        Processing score
+        Processing, check back soon
       </span>
     </a>
     <button

--- a/src/enum/FileExtensions.js
+++ b/src/enum/FileExtensions.js
@@ -1,5 +1,5 @@
 const FileExtensions = {
-  scoreUrl    : ["mei", "xml", "pdf"],
+  scoreUrl    : ["mei", "xml", "pdf", "mxl"],
   thumbnailUrl: ["jpg", "jpeg", "png", "gif"],
 };
 

--- a/src/i18n/locales/en/campaign.json
+++ b/src/i18n/locales/en/campaign.json
@@ -34,7 +34,7 @@
     "days_to_go": "{{count}} day to go",
     "days_to_go_plural": "{{count}} days to go",
     "description": "Let's work together on bringing Mahler's 6th to our yearly outdoor performance. This version would be perfect, but the quality of the PDF is really insufficient. Can you all help cleaning it up? We've got five weeks to do it, people!",
-    "processing_score": "Processing score"
+    "processing_score": "Processing, check back soon"
   },
   "mailchimp": {
     "keep_you_posted": "We'll keep you posted",

--- a/src/screens/ActiveCampaign/ActiveCampaign.jsx
+++ b/src/screens/ActiveCampaign/ActiveCampaign.jsx
@@ -110,7 +110,7 @@ export default function ActiveCampaign ({ match }) {
           openSubscribeForm={openSubscribeForm}
         />
       </Jumbotron>
-      <TaskGroupProgress digitalDocumentIdentifier={digitalDocument.identifier} />
+      <TaskGroupProgress digitalDocumentIdentifier={digitalDocument?.identifier} />
       <ActiveCampaignTwoSections
         campaign={campaign}
         digitalDocument={digitalDocument}

--- a/src/screens/ActiveCampaign/ActiveCampaign.jsx
+++ b/src/screens/ActiveCampaign/ActiveCampaign.jsx
@@ -130,7 +130,7 @@ export default function ActiveCampaign ({ match }) {
               campaignTitle={campaign.title}
               campaignDeadline={daysToGo}
               onClick={() => {
-                history.push(`/campaign/${campaign.identifier}`);
+                history.push(`/campaign/${campaign?.identifier}`);
               }}
             />
           );})}


### PR DESCRIPTION
This PR:
 - Adds support for the 'mxl' file extension in the solidpodbrowser implementation
 - Fixes an error when the digitalDocument is still undefined, when creating taskgroup progress
 - Fixes an error when the campaign is still undefined, after submitting a new campaign