### PR TITLE
Feat / use cleaner solidpodbrowser url

### DIFF
--- a/.env
+++ b/.env
@@ -12,7 +12,7 @@ REACT_APP_PROCESSING_CAMPAIGN_IDENTIFIER=ba4314b7-2f47-4d6f-81d1-8bafb8b8f22c
 REACT_APP_API_BASE_URL=https://sl-api.trompamusic.eu/
 
 # Solid pod browser
-REACT_APP_SOLID_POD_BROWSER_URL=https://d1d5z0tgwk7nsn.cloudfront.net
+REACT_APP_SOLID_POD_BROWSER_URL=https://solidpodbrowser.trompamusic.eu
 
 # Aws sdk
 REACT_APP_AWS_SDK_BUCKET_NAME=trompa-upload


### PR DESCRIPTION
This PR updates the env variable of the solidpodbrowser to the cleaner 'solidpodbrowser.trompamusic.eu', which directs to the cloudfront that hosts the pod browser.