### PR TITLE
Feat / load next task on iframe submit

### DIFF
--- a/src/components/ActiveTask/ActiveTask.jsx
+++ b/src/components/ActiveTask/ActiveTask.jsx
@@ -34,7 +34,7 @@ export default function ActiveTask ({
 
   useEffect(() => {
     const iframeListener = ({ data }) => {
-      if(data === 'submit'){
+      if (data === 'submit'){
         handleSubmit();
       }
     };

--- a/src/components/ActiveTask/ActiveTask.jsx
+++ b/src/components/ActiveTask/ActiveTask.jsx
@@ -32,7 +32,6 @@ export default function ActiveTask ({
     handleNotification('success', t('notifications:thank_you_for_contributing'));
   }, [onNextTaskButtonClick, handleNotification, t]);
 
-  // Listen to submit message from iframe: window.parent.postMessage('submit', '*')
   useEffect(() => {
     const iframeListener = ({ data }) => {
       if(data === 'submit'){

--- a/src/components/ActiveTask/ActiveTask.jsx
+++ b/src/components/ActiveTask/ActiveTask.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { makeStyles } from '@material-ui/styles';
 import { useTranslation } from 'react-i18next';
@@ -26,6 +26,24 @@ export default function ActiveTask ({
 }) {
   const { t }   = useTranslation('task');
   const classes = useStyles();
+
+  const handleSubmit = useCallback(() => {
+    onNextTaskButtonClick();
+    handleNotification('success', t('notifications:thank_you_for_contributing'));
+  }, [onNextTaskButtonClick, handleNotification, t]);
+
+  // Listen to submit message from iframe: window.parent.postMessage('submit', '*')
+  useEffect(() => {
+    const iframeListener = ({ data }) => {
+      if(data === 'submit'){
+        handleSubmit();
+      }
+    };
+
+    window.addEventListener('message', iframeListener);
+
+    return () => window.removeEventListener('message', iframeListener);
+  }, [handleNotification, handleSubmit, onNextTaskButtonClick, t]);
 
   return (
     <React.Fragment>
@@ -75,10 +93,7 @@ export default function ActiveTask ({
         )}
         {!loading && !noTasks && (
           <Button
-            onClick={() => {
-              onNextTaskButtonClick();
-              handleNotification('success', t('notifications:thank_you_for_contributing'));
-            }}
+            onClick={handleSubmit}
             variant="contained"
             color="primary"
           >

--- a/src/components/ActiveTask/ActiveTask.jsx
+++ b/src/components/ActiveTask/ActiveTask.jsx
@@ -93,10 +93,9 @@ export default function ActiveTask ({
         {!loading && !noTasks && (
           <Button
             onClick={handleSubmit}
-            variant="contained"
             color="primary"
           >
-            {t('next_task')}
+            {t('skip_task')}
           </Button>
         )}
       </AppbarBottom>

--- a/src/components/ActiveTask/ActiveTask.test.jsx
+++ b/src/components/ActiveTask/ActiveTask.test.jsx
@@ -12,7 +12,7 @@ describe('<ActiveTask />', () => {
   test('displays next task with task props', () => {
     const { getByText } = render(<ActiveTask name="abc" url="https://demo.videodock.com/trompa/ce-task" />);
 
-    expect(getByText('Next task')).toBeTruthy();
+    expect(getByText('Skip task')).toBeTruthy();
   });
 
   test('displays loading with loading prop', () => {

--- a/src/i18n/locales/en/task.json
+++ b/src/i18n/locales/en/task.json
@@ -2,7 +2,7 @@
   "close": "Close",
   "description": "Work on tasks related to the selected campaign.",
   "loading": "Loading...",
-  "next_task": "Next task",
+  "skip_task": "Skip task",
   "no_tasks_left": "No tasks left",
   "no_tasks_available": "There are currently no tasks available for this campaign",
   "this_task_is_not_yet_available": "This task is not yet available.",


### PR DESCRIPTION
This PR:
- Adds a postMessage listener on the ActiveTask page, so that a task submit from the iframe will trigger loading the next task.
- Changes the 'Next task' button label to 'Skip task', to keep the function of skipping a task

`window.parent.postMessage('submit', '*')`