### PR TITLE
Feat / Add periodic task refetching to campaign page

### DIFF
--- a/src/containers/Task/Task.jsx
+++ b/src/containers/Task/Task.jsx
@@ -64,7 +64,7 @@ export default function Task({ campaignIdentifier, taskIdentifier }) {
 
   useEffect(() => {
     if (!taskIdentifier && score) {
-      getTaskList({ variables: { identifier: score.identifier, filtered: tasksSubmitted, drawamount: taskDrawAmount } });
+      getTaskList({ variables: { identifier: score.identifier, filtered: tasksSubmitted, drawAmount: taskDrawAmount } });
     }
     if (taskIdentifier){
       getTask({ variables: { identifiers: [taskIdentifier] } });
@@ -119,7 +119,7 @@ Task.propTypes = {
 };
 
 export const ALL_TASKS = gql`
-    query AllPotentialActions($identifier: ID! $filtered: [ID!] $drawamount: Int) {
+    query AllPotentialActions($identifier: ID! $filtered: [ID!] $drawAmount: Int) {
       ControlAction(
           filter: {
               wasGeneratedBy_not: null
@@ -128,7 +128,7 @@ export const ALL_TASKS = gql`
               object_single: { identifier: $identifier }
               identifier_not_in: $filtered
           }
-          first: $drawamount
+          first: $drawAmount
       ) {
           identifier
       }


### PR DESCRIPTION
This PR:
- adds periodic refetching once there are no tasks (anymore)
- adds filtering to make sure submitted tasks aren't refetched
- refactoring: uses useLazyQuery for fetching instead of client.query for better readability