### PR TITLE
Fix / dissappearing header on mobile

### DIFF
--- a/src/components/CreateCampaignSetup/CreateCampaignSetup.styles.js
+++ b/src/components/CreateCampaignSetup/CreateCampaignSetup.styles.js
@@ -30,6 +30,9 @@ export default ({ typography, palette, spacing, breakpoints }) => createStyles({
     margin: spacing(4),
   },
   header: {
+    [breakpoints.down('xs')]: {
+      marginTop: spacing(3),
+    },
     [breakpoints.down('sm')]: {
       fontSize: typography.pxToRem(28),
     },


### PR DESCRIPTION
This PR fixes a dissappearing header on the CreateCampaignSetup page on mobile